### PR TITLE
Fix arguments validation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ async fn run_js(file_path: &str) -> Result<(), AnyError> {
 fn main() {
     let args: Vec<String> = std::env::args().collect();
 
-    if args.is_empty() {
+    if args.len() <= 1 {
         eprintln!("Usage: runjs <file>");
         std::process::exit(1);
     }


### PR DESCRIPTION
Thanks for the great article!

One point, I found some code that may not be what I intended, so I created a PR.
If I run the original code without specifying the file on the command line, I get the following error

```bash
$ cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/runjs`
thread 'main' panicked at 'index out of bounds: the len is 1 but the index is 1', src/main.rs:132:22
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

I have modified the process to ensure that the command line arguments are specified.